### PR TITLE
bugfix: casa cant load MFA methods enabled on oxauth

### DIFF
--- a/app/src/main/java/org/gluu/casa/core/PersistenceService.java
+++ b/app/src/main/java/org/gluu/casa/core/PersistenceService.java
@@ -301,6 +301,7 @@ public class PersistenceService implements IPersistenceService {
         CustomScript script = new CustomScript();
         script.setDisplayName(acr);
         script.setBaseDn(getCustomScriptsDn());
+        script.setEnabled(true);
 
         List<CustomScript> scripts = find(script);
         if (scripts.size() == 0) {


### PR DESCRIPTION
Casa can't search in opendj for enabeld MFA methods in oxauth because the search filter ends up with:
```
...(oxEnabled=false)...
```
