### PR TITLE
fix: person model class has been updated

### DIFF
--- a/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
+++ b/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
@@ -47,13 +47,13 @@ public class HomeViewModel {
 
         JSONObject jsonObject = Optional.ofNullable(evt.getData()).map(JSONObject.class::cast).orElse(null);
         if (jsonObject != null) {
-            logger.trace("Browser data is {} ", jsonObject.toJSONString());
+            logger.trace("Browser data is {} ", logger.isTraceEnabled() ? jsonObject.toJSONString() : "");
 
             updateOffset(jsonObject.get("offset"));
             updateScreenWidth(jsonObject.get("screenWidth"));
 
             boolean mobile = Optional.ofNullable(jsonObject.get("isMobile")).map(Boolean.class::cast).orElse(false);
-            logger.trace("Detected browser is {} mobile", mobile ? "" : "not");
+            logger.trace("Detected browser is {0} mobile", mobile ? "" : "not");
             updateBrowserInfo(jsonObject.get("name"), jsonObject.get("version"), mobile);
         }
 
@@ -69,7 +69,7 @@ public class HomeViewModel {
                 int offset = (int) value;
                 ZoneOffset zoffset = ZoneOffset.ofTotalSeconds(offset);
                 sessionContext.setZoneOffset(zoffset);
-                logger.trace("Time offset for session is {}", zoffset.toString());
+                logger.trace("Time offset for session is {0}", logger.isTraceEnabled() ? zoffset.toString() : "");
             }
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
+++ b/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
@@ -47,7 +47,7 @@ public class HomeViewModel {
 
         JSONObject jsonObject = Optional.ofNullable(evt.getData()).map(JSONObject.class::cast).orElse(null);
         if (jsonObject != null) {
-            logger.trace("Browser data is {} ", logger.isTraceEnabled() ? jsonObject.toJSONString() : "");
+            logger.trace("Browser data is {} ", logger.isTraceEnabled() ? jsonObject : "");
 
             updateOffset(jsonObject.get("offset"));
             updateScreenWidth(jsonObject.get("screenWidth"));
@@ -69,7 +69,7 @@ public class HomeViewModel {
                 int offset = (int) value;
                 ZoneOffset zoffset = ZoneOffset.ofTotalSeconds(offset);
                 sessionContext.setZoneOffset(zoffset);
-                logger.trace("Time offset for session is {0}", logger.isTraceEnabled() ? zoffset.toString() : "");
+                logger.trace("Time offset for session is {0}", logger.isTraceEnabled() ? zoffset : "");
             }
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
+++ b/app/src/main/java/org/gluu/casa/ui/vm/HomeViewModel.java
@@ -4,7 +4,7 @@ import org.gluu.casa.core.SessionContext;
 import org.gluu.casa.core.pojo.BrowserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zkoss.bind.annotation.AfterCompose;;
+import org.zkoss.bind.annotation.AfterCompose;
 import org.zkoss.bind.annotation.ContextParam;
 import org.zkoss.bind.annotation.ContextType;
 import org.zkoss.bind.annotation.Init;

--- a/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
+++ b/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
@@ -35,7 +35,7 @@ public class BasePerson extends InumEntry {
     private static String[] customObjectClasses;
 
     @AttributesList(name = "name", value = "values", multiValued = "multiValued", sortByName = true)
-    private List<CustomObjectAttribute> customAttributes = new ArrayList<CustomObjectAttribute>();
+    private List<CustomObjectAttribute> customAttributes = new ArrayList<>();
 
     static {
         IPersistenceService ips = Utils.managedBean(IPersistenceService.class);

--- a/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
+++ b/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
@@ -35,7 +35,7 @@ public class BasePerson extends InumEntry {
     private static String[] customObjectClasses;
 
     @AttributesList(name = "name", value = "values", multiValued = "multiValued", sortByName = true)
-    protected List<CustomObjectAttribute> customAttributes = new ArrayList<CustomObjectAttribute>();
+    private List<CustomObjectAttribute> customAttributes = new ArrayList<CustomObjectAttribute>();
 
     static {
         IPersistenceService ips = Utils.managedBean(IPersistenceService.class);

--- a/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
+++ b/shared/src/main/java/org/gluu/casa/core/model/BasePerson.java
@@ -2,12 +2,16 @@ package org.gluu.casa.core.model;
 
 import org.gluu.casa.misc.Utils;
 import org.gluu.casa.service.IPersistenceService;
+import org.gluu.persist.model.base.CustomObjectAttribute;
 import org.gluu.persist.model.base.InumEntry;
 import org.gluu.persist.annotation.AttributeName;
+import org.gluu.persist.annotation.AttributesList;
 import org.gluu.persist.annotation.CustomObjectClass;
 import org.gluu.persist.annotation.DataEntry;
 import org.gluu.persist.annotation.ObjectClass;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -19,11 +23,19 @@ import java.util.Set;
 @ObjectClass("gluuPerson")
 public class BasePerson extends InumEntry {
 
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 6952879204157214152L;
+
     @AttributeName
     private String uid;
 
     @CustomObjectClass
     private static String[] customObjectClasses;
+
+    @AttributesList(name = "name", value = "values", multiValued = "multiValued", sortByName = true)
+    protected List<CustomObjectAttribute> customAttributes = new ArrayList<CustomObjectAttribute>();
 
     static {
         IPersistenceService ips = Utils.managedBean(IPersistenceService.class);
@@ -51,4 +63,11 @@ public class BasePerson extends InumEntry {
         BasePerson.customObjectClasses = customObjectClasses;
     }
 
+    public List<CustomObjectAttribute> getCustomAttributes() {
+        return customAttributes;
+    }
+
+    public void setCustomAttributes(List<CustomObjectAttribute> customAttributes) {
+        this.customAttributes = customAttributes;
+    }
 }


### PR DESCRIPTION
fix: person model class has been updated (for support of customized person objects);
The root of this update is follow...
For example, we have customized person (it can be provided, updating schema and regoster.py script):
![image](https://user-images.githubusercontent.com/8136531/204149089-4426ff28-e5fb-4e9f-a3ca-265f88d99460.png)
Here is customized person class **netcPerson** and new attribute: **userStatus**.
Then here:
![image](https://user-images.githubusercontent.com/8136531/204149222-17a6c561-cfd9-4577-9508-996d3c8bafd7.png)
i.e. during setup of 2FA, update of  customized person is provided, this (selected) attribute is updated:
![image](https://user-images.githubusercontent.com/8136531/204149287-1d068645-0ccb-44cc-9f55-ac3dab0d8f86.png)
.
This update is provided here:
![image](https://user-images.githubusercontent.com/8136531/204149580-9913fd09-63bb-4309-a825-2a85181ada5b.png)
Result is **false**.
This commit and **PR** resolves the issue, described below.
![image](https://user-images.githubusercontent.com/8136531/204149770-ee36c060-0cc9-440b-8f9a-4846f03dedef.png)
Update of **2FA** status (attribute **oxPrefferedMethod**) works OK.
